### PR TITLE
Potential fix for code scanning alert no. 2: Double escaping or unescaping

### DIFF
--- a/src/extension/chat.ts
+++ b/src/extension/chat.ts
@@ -597,11 +597,11 @@ export class Chat extends Base {
       return {
         ...message,
         conversationId: id || message.id, // Preserve the conversationId
-        content: stringContent.replace(/&lt;/g, "<")
+        content: stringContent.replace(/&amp;/g, "&")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
         .replace(/@problems/g, "").trim()
         .replace(/@workspace/g, "").trim()
-        .replace(/&amp;/g, "&")
-        .replace(/&gt;/g, ">")
         .replace(/<span[^>]*data-type="mention"[^>]*>(.*?)<\/span>/g, "$1")
         .trimStart()
       }


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/twinny/security/code-scanning/2](https://github.com/MjrTom/twinny/security/code-scanning/2)

To fix the problem, we need to reorder the replacements in the `content` property of the returned object. Specifically, the replacement of `&amp;` with `&` should be done first, followed by the replacements of `&lt;`, `&gt;`, and other entities. This ensures that any escaped ampersands are correctly unescaped before other entities are processed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
