### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/src/webview/message.tsx
+++ b/src/webview/message.tsx
@@ -191,7 +191,7 @@ export const Message: React.FC<MessageProps> = ({
     const mentions = Array.from(doc.querySelectorAll(".mention")).map(
       (mention) => {
         const filePath = DOMPurify.sanitize(mention.getAttribute("data-id"))
-        const label = mention.getAttribute("data-label")
+        const label = DOMPurify.sanitize(mention.getAttribute("data-label"))
         if (filePath && label) {
           mention.outerHTML = `<span class="mention" data-type="mention" data-id="${filePath}" data-label="${label}">@${label}</span>`
         }


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/twinny/security/code-scanning/3](https://github.com/MjrTom/twinny/security/code-scanning/3)

To fix the problem, we need to ensure that the `label` attribute is properly sanitized before being used in the HTML string. We can use `DOMPurify.sanitize` to sanitize the `label` attribute, similar to how `filePath` is sanitized. This will prevent any malicious scripts from being executed.

- Sanitize the `label` attribute using `DOMPurify.sanitize`.
- Ensure that both `filePath` and `label` are safe to use in the HTML string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
