### PR TITLE
Potential fix for code scanning alert no. 5: Client-side cross-site scripting

### DIFF
--- a/src/webview/review.tsx
+++ b/src/webview/review.tsx
@@ -1,4 +1,5 @@
 import React, { FormEvent, useEffect } from "react"
+import DOMPurify from "dompurify"
 import { useTranslation } from "react-i18next"
 import { VSCodeButton, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 
@@ -78,7 +79,7 @@ export const Review = () => {
             {prs.map((pr) => (
               <li key={pr.number} className={styles.prItem}>
                 <span className={styles.prTitle}>
-                  <a href={pr.html_url}>
+                  <a href={DOMPurify.sanitize(pr.html_url)}>
                     {pr.title} (#{pr.number})
                   </a>
                 </span>


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/twinny/security/code-scanning/5](https://github.com/MjrTom/twinny/security/code-scanning/5)

To fix the problem, we need to ensure that the `html_url` value is properly sanitized before being used in the `href` attribute of the anchor tag. One way to achieve this is by using a library like `DOMPurify` to sanitize the URL. This will help prevent any malicious scripts from being executed.

1. Install the `DOMPurify` library.
2. Import `DOMPurify` in the relevant file.
3. Use `DOMPurify` to sanitize the `html_url` before using it in the `href` attribute.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
