### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/src/webview/message.tsx
+++ b/src/webview/message.tsx
@@ -190,8 +190,8 @@ export const Message: React.FC<MessageProps> = ({
     const doc = parser.parseFromString(editorContent, "text/html")
     const mentions = Array.from(doc.querySelectorAll(".mention")).map(
       (mention) => {
-        const filePath = mention.getAttribute("data-id")
-        const label = mention.getAttribute("data-label")
+        const filePath = DOMPurify.sanitize(mention.getAttribute("data-id"))
+        const label = DOMPurify.sanitize(mention.getAttribute("data-label"))
         if (filePath && label) {
           mention.outerHTML = `<span class="mention" data-type="mention" data-id="${filePath}" data-label="${label}">@${label}</span>`
         }


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/twinny/security/code-scanning/3](https://github.com/MjrTom/twinny/security/code-scanning/3)

To fix the problem, we need to ensure that the `filePath` and `label` variables are properly sanitized before being used in the HTML string. We can use a library like `DOMPurify` to sanitize the values and prevent XSS attacks.

- Import `DOMPurify` if it is not already imported.
- Use `DOMPurify.sanitize` to sanitize the `filePath` and `label` variables before interpolating them into the HTML string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
